### PR TITLE
Use chunk constant pool to keep global variable names

### DIFF
--- a/docs/znai/virtual-machine/instructions.md
+++ b/docs/znai/virtual-machine/instructions.md
@@ -83,17 +83,16 @@ Note that the offset can be negative.
 
 # Global variables
 
-Global variable instructions access global variables by the name.
+Global variable instructions access global variables by the name. 
+Compiler places the variable name into constants pool of bytecode chunk.
 
 Loading the variable places the value on stack.
 Storing the variable replaces the value in globals map via the topmost value on the stack.
 
 | Mnemonics | Parameters | Effect |
 | :--- | :---- | :--- |
-| `LD_G <name>` | name - the name of the variable | Copies the value of the global variable onto the stack |
-| `ST_G <name>` | name - the name of the variable | Copies the value from the top of the stack to the globals map |
-
-Warning: the mnemonics of globals instructions is about to change. The `name` parameter will refer to the index in the constant pool rather than the actual variable name.
+| `LD_G <idx>` | idx - constant index containing variable name | Copies the value of the global variable onto the stack |
+| `ST_G <idx>` | idx - constant index containing variable name | Copies the value from the top of the stack to the globals map |
 
 # Local variables
 

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -455,7 +455,7 @@ mod tests {
                 Op::ConstFloat(1.0),
                 Op::StoreGlobal(0),
                 Op::Pop,
-                Op::LoadGlobal(1),
+                Op::LoadGlobal(0),
                 Op::StoreLocal(0),
                 Op::Pop,
             ]

--- a/src/value.rs
+++ b/src/value.rs
@@ -145,6 +145,16 @@ impl ValueType {
     }
 }
 
+// Set of helper functions to build value types easier
+impl ValueType {
+    pub fn string<T>(value: T) -> ValueType
+    where
+        T: Into<String>,
+    {
+        ValueType::Text(Box::new(value.into()))
+    }
+}
+
 impl Display for ValueType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/src/vm/opcode.rs
+++ b/src/vm/opcode.rs
@@ -113,6 +113,15 @@ impl Chunk {
     }
 
     pub fn add_constant(&mut self, value: ValueType) -> usize {
+        let i = self
+            .constants
+            .iter()
+            .enumerate()
+            .find(|(_, v)| **v == value)
+            .map(|(i, _)| i);
+        if let Some(idx) = i {
+            return idx;
+        }
         self.constants.push(value);
         self.constants.len() - 1
     }
@@ -240,5 +249,22 @@ mod tests {
         chunk.patch_jump_to(jump_address, target_address);
 
         assert_eq!(chunk.op(jump_address), Some(&Op::Jump(-3)));
+    }
+
+    #[test]
+    fn reuse_constant_pool_entries() {
+        let mut chunk = Chunk::default();
+        let foo_index = chunk.add_constant(ValueType::string("foo"));
+        let bar_index = chunk.add_constant(ValueType::string("bar"));
+        let duplicate_index = chunk.add_constant(ValueType::string("foo"));
+
+        assert_eq!(
+            foo_index, duplicate_index,
+            "constant pool put duplicate entry in a separate constant pool entry"
+        );
+        assert_ne!(
+            foo_index, bar_index,
+            "constant pool put different constants in the same entry"
+        );
     }
 }

--- a/src/vm/opcode.rs
+++ b/src/vm/opcode.rs
@@ -35,9 +35,11 @@ pub enum Op {
     /// Prints value on top of the stack.
     Print,
     /// Takes the value from the top of the stack and stores it in the global variable.
-    StoreGlobal(String),
+    /// The name of the variable is taken from the constant pool.
+    StoreGlobal(usize),
     /// Load global variable value onto the stack.
-    LoadGlobal(String),
+    /// The name of the variable is taken from the constant pool.
+    LoadGlobal(usize),
     /// Takes the value from the top of the stack and stores it in the local variable.
     StoreLocal(usize),
     /// Load local variable value onto the stack.
@@ -69,8 +71,8 @@ impl Display for Op {
             Op::Ge => write!(f, "GE"),
             Op::Not => write!(f, "NEG"),
             Op::Print => write!(f, "PRN"),
-            Op::LoadGlobal(name) => write!(f, "LD_G, {}", name),
-            Op::StoreGlobal(name) => write!(f, "ST_G, {}", name),
+            Op::LoadGlobal(idx) => write!(f, "LD_G, {}", idx),
+            Op::StoreGlobal(idx) => write!(f, "ST_G, {}", idx),
             Op::LoadLocal(idx) => write!(f, "LD_L, {}", idx),
             Op::StoreLocal(idx) => write!(f, "ST_L, {}", idx),
             Op::Pop => write!(f, "POP"),


### PR DESCRIPTION
The global variable instructions `LD_G` and `ST_G` use string operands to keep variable names.
This representation has two problems:

- It is inconsistent with other VM instructions;
- It complicates the bytecode serialization;

The PR keeps variable names in a bytecode chunk constant pool instead of using them directly.

The PR also changes a constant pool behaviour. 
The pool will check existing constants on add and will not create a new constant if it's already in the pool.
It will return the index of existing constant instead.

- feat: use constants pool for global names
- feat: reuse constant pool entries
- docs: update global vars instructions
