### PR TITLE
fix clippy findings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,6 +48,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Generate code coverage
         run: |
-          cargo +nightly tarpaulin --verbose --all-features --workspace --timeout 120 --out Xml
+          cargo tarpaulin --verbose --all-features --workspace --timeout 120 --out Xml
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3

--- a/benches/brainfuck_benchmark.rs
+++ b/benches/brainfuck_benchmark.rs
@@ -3,7 +3,6 @@ use std::error::Error;
 use std::fs::File;
 use std::rc::Rc;
 
-
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 use brainterpreter::compiler::Compiler;

--- a/benches/brainfuck_benchmark.rs
+++ b/benches/brainfuck_benchmark.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 use std::fs::File;
 use std::rc::Rc;
 
-use brainterpreter::ast::Program;
+
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 use brainterpreter::compiler::Compiler;

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -387,7 +387,7 @@ impl Vm {
 
 impl Default for Vm {
     fn default() -> Self {
-        let tracer = LoggingTracer::default();
+        let tracer = LoggingTracer;
         let out = stdout();
         let mut vm = Vm {
             stack: VmStack::default(),


### PR DESCRIPTION
A new rust release added clippy checks which found issues in the code.
Also the code coverage with tarpaulin in nightly is broken. 
The PR disables nightly flag in coverage check workflow

- fix(clippy): remove default initializer
- chore(formatting): apply correct formatting
- ci: disable coverage report on rust nightly
